### PR TITLE
Allow custom HTTP Header field for the JWT Token

### DIFF
--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -223,7 +223,8 @@ class Simple_Jwt_Authentication_Rest {
 		 * Looking for the HTTP_AUTHORIZATION header, if not present just
 		 * return the user.
 		 */
-		$auth = isset( $_SERVER['HTTP_AUTHORIZATION'] ) ? $_SERVER['HTTP_AUTHORIZATION'] : false;
+		$header_name = defined("SIMPLE_JWT_AUTHENTICATION_HEADER_NAME") ? SIMPLE_JWT_AUTHENTICATION_HEADER_NAME : "HTTP_AUTHORIZATION";
+		$auth = isset( $_SERVER[$header_name] ) ? $_SERVER[$header_name] : false;
 
 		// Double check for different auth header string (server dependent)
 		if ( ! $auth ) {


### PR DESCRIPTION
When trying to use HTTP Basic Auth together with another Auth scheme like JWT, you face two issues that are circumvented by this Pull Request.
First: It is not really supported to add multiple Authorization schemes (Authorization: Basic [BASIC-Token], Bearer [JWT-Token]). And second does this plugin always fails, if the "Authorization" header contains anything else than "Bearer ...".

Allowing a custom header field for the JWT Auth will make such situations work. In our case, it is for a testing environment where Basic Auth is always present.
The default should nevertheless remain the HTTP_AUTHORIZATION header.

This PR allows you to control the header field name to look for the JWT token by an entry within wp-config.php.

Best Regards,
Jan
  