### PR TITLE
Add type so Bedrock based installers can install the plugin with Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "jonathan-dejong/simple-jwt-authentication",
+    "type": "wordpress-plugin",
     "description": "Extends the WP REST API using JSON Web Tokens Authentication as an authentication method",
     "config": {
         "vendor-dir": "includes/vendor"


### PR DESCRIPTION
First I tried to install this by just running `composer require jonathan-dejong/simple-jwt-authentication`, then I realized that it's not on Packagist, and added the repository as a vcs, and tried again.

The plugin installed, but it went to the /vendor/ directory instead of the wp-content/plugins folder. With this it goes to the plugins folder. 

And please consider submitting this to Packagist, it takes about 5 minutes of your time :) 