### PR TITLE
Make UUID generation backwards compatible 

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Donate link: http://fancy.to/scbk86
 Tags: wp-rest, api, jwt, authentication, access
 Requires at least: 3.0.1
 Tested up to: 4.8
-Stable tag: 1.1
+Stable tag: 1.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "type": "wordpress-plugin",
     "description": "Extends the WP REST API using JSON Web Tokens Authentication as an authentication method",
     "config": {
-        "vendor-dir": "includes/vendor"
+      "vendor-dir": "includes/vendor"
     },
     "require": {
-        "firebase/php-jwt": "^3.0",
-		"donatj/phpuseragentparser": "*"
+      "firebase/php-jwt": "^3.0",
+			"donatj/phpuseragentparser": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     },
     "require": {
         "firebase/php-jwt": "^3.0",
-		"donatj/phpuseragentparser": "*"
+		"donatj/phpuseragentparser": "*",
+        "ramsey/uuid": "^3.8"
     }
 }

--- a/includes/admin/class-simple-jwt-authentication-profile.php
+++ b/includes/admin/class-simple-jwt-authentication-profile.php
@@ -9,7 +9,7 @@ class Simple_Jwt_Authentication_Profile {
 
 	protected $plugin_name;
 	protected $plugin_version;
-
+	protected $user;
 
 	/**
 	 * Initialize the class and set its properties.
@@ -20,17 +20,21 @@ class Simple_Jwt_Authentication_Profile {
 		$this->plugin_name = $plugin_name;
 		$this->plugin_version = $plugin_version;
 
+		add_action( 'init', array( $this, 'set_edited_user' ) );
+
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 		add_action( 'edit_user_profile', array( $this, 'user_token_ui' ), 20 );
 		add_action( 'show_user_profile', array( $this, 'user_token_ui' ), 20 );
-		add_action( 'edit_user_profile', array( $this, 'maybe_revoke_token' ) );
+		add_action( 'init', array( $this, 'maybe_revoke_token' ) );
 		add_action( 'show_user_profile', array( $this, 'maybe_revoke_token' ) );
-		add_action( 'edit_user_profile', array( $this, 'maybe_revoke_all_tokens' ) );
+		add_action( 'init', array( $this, 'maybe_revoke_all_tokens' ) );
 		add_action( 'show_user_profile', array( $this, 'maybe_revoke_all_tokens' ) );
-		add_action( 'edit_user_profile', array( $this, 'maybe_remove_expired_tokens' ) );
+		add_action( 'init', array( $this, 'maybe_remove_expired_tokens' ) );
 		add_action( 'show_user_profile', array( $this, 'maybe_remove_expired_tokens' ) );
 
 	}
+
+
 
 
 	public function admin_notices() {
@@ -71,49 +75,43 @@ class Simple_Jwt_Authentication_Profile {
 	/**
 	 * Check if we should revoke a token.
 	 *
-	 * @param object $user A WP_User object
 	 * @since 1.0
 	 */
-	public function maybe_revoke_token( $user ) {
-		if ( current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_token'] ) ) {
-
-			$tokens = get_user_meta( $user->ID, 'jwt_data', true ) ?: false;
+	public function maybe_revoke_token() {
+		if ( $this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_token'] ) ) {
+			$tokens = get_user_meta( $this->user->ID, 'jwt_data', true ) ?: false;
 			$request_token = $_GET['revoke_token'];
 
 			if ( $tokens ) {
 				foreach ( $tokens as $key => $token ) {
 					if ( $token['uuid'] == $_GET['revoke_token'] ) {
 						unset( $tokens[ $key ] );
-						update_user_meta( $user->ID , 'jwt_data', $tokens );
+						update_user_meta( $this->user->ID , 'jwt_data', $tokens );
 						break;
 					}
 				}
 			}
 
-			$current_url = ( isset( $_SERVER['HTTPS'] ) ? 'https' : 'http' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+			$current_url = get_home_url().$_SERVER['REQUEST_URI'];
 			$redirect_url = add_query_arg( array(
 				'jwtupdated' => 1,
 				'revoked' => $request_token,
 			), remove_query_arg( array( 'revoke_token' ), $current_url ) );
 			wp_safe_redirect( $redirect_url );
 			exit;
-
 		}
-
 	}
-
 
 	/**
 	 * Check if we should revoke a token.
 	 *
-	 * @param object $user A WP_User object
 	 * @since 1.0
 	 */
-	public function maybe_revoke_all_tokens( $user ) {
-		if ( current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_all_tokens'] ) ) {
-			delete_user_meta( $user->ID, 'jwt_data' );
+	public function maybe_revoke_all_tokens() {
+		if ( $this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_all_tokens'] ) ) {
+			delete_user_meta( $this->user->ID, 'jwt_data' );
+			$current_url = get_home_url().$_SERVER['REQUEST_URI'];
 
-			$current_url = ( isset( $_SERVER['HTTPS'] ) ? 'https' : 'http' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
 			$redirect_url = add_query_arg( array(
 				'jwtupdated' => 1,
 				'revoked' => 'all',
@@ -129,23 +127,22 @@ class Simple_Jwt_Authentication_Profile {
 	/**
 	 * Check if we should revoke a token.
 	 *
-	 * @param object $user A WP_User object
 	 * @since 1.0
 	 */
-	public function maybe_remove_expired_tokens( $user ) {
-		if ( current_user_can( 'edit_user' ) && ! empty( $_GET['remove_expired_tokens'] ) ) {
+	public function maybe_remove_expired_tokens() {
+		if ($this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['remove_expired_tokens'] ) ) {
 
-			$tokens = get_user_meta( $user->ID, 'jwt_data', true ) ?: false;
+			$tokens = get_user_meta( $this->user->ID, 'jwt_data', true ) ?: false;
 			if ( $tokens ) {
 				foreach ( $tokens as $key => $token ) {
 					if ( $token['expires'] < time() ) {
 						unset( $tokens[ $key ] );
 					}
 				}
-				update_user_meta( $user->ID , 'jwt_data', $tokens );
+				update_user_meta( $this->user->ID , 'jwt_data', $tokens );
 			}
 
-			$current_url = ( isset( $_SERVER['HTTPS'] ) ? 'https' : 'http' ) . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";
+			$current_url = get_home_url().$_SERVER['REQUEST_URI'];
 			$redirect_url = add_query_arg( array(
 				'jwtupdated' => 1,
 				'removed' => 'all',
@@ -155,5 +152,19 @@ class Simple_Jwt_Authentication_Profile {
 		}
 	}
 
+	/**
+	 * check if is edit user page, and if user exist from GET param
+	 *
+	 * @since 1.1.1
+	 */
+	public function set_edited_user() {
+		$user = null;
+		if( ! empty( $_GET['user_id'] ) ){
+			// If ID is incorrect, user will not be found, and function return null
+			$user = get_userdata( (int)$_GET['user_id'] );
+			if($user) $user = $user->data;
+		}
+		$this->user = $user;
+	}
 }
 new Simple_Jwt_Authentication_Profile( $plugin_name, $plugin_version );

--- a/includes/admin/class-simple-jwt-authentication-profile.php
+++ b/includes/admin/class-simple-jwt-authentication-profile.php
@@ -63,7 +63,7 @@ class Simple_Jwt_Authentication_Profile {
 	 * @since 1.0
 	 */
 	public function user_token_ui( $user ) {
-		if ( current_user_can( 'edit_user' ) ) {
+		if ( current_user_can( 'edit_users' ) ) {
 			$tokens = get_user_meta( $user->ID, 'jwt_data', true ) ?: false;
 			include plugin_dir_path( __FILE__ ) . 'views/user-token-ui.php';
 
@@ -78,7 +78,7 @@ class Simple_Jwt_Authentication_Profile {
 	 * @since 1.0
 	 */
 	public function maybe_revoke_token() {
-		if ( $this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_token'] ) ) {
+		if ( $this->user && current_user_can( 'edit_users' ) && ! empty( $_GET['revoke_token'] ) ) {
 			$tokens = get_user_meta( $this->user->ID, 'jwt_data', true ) ?: false;
 			$request_token = $_GET['revoke_token'];
 
@@ -108,7 +108,7 @@ class Simple_Jwt_Authentication_Profile {
 	 * @since 1.0
 	 */
 	public function maybe_revoke_all_tokens() {
-		if ( $this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['revoke_all_tokens'] ) ) {
+		if ( $this->user && current_user_can( 'edit_users' ) && ! empty( $_GET['revoke_all_tokens'] ) ) {
 			delete_user_meta( $this->user->ID, 'jwt_data' );
 			$current_url = get_home_url().$_SERVER['REQUEST_URI'];
 
@@ -130,7 +130,7 @@ class Simple_Jwt_Authentication_Profile {
 	 * @since 1.0
 	 */
 	public function maybe_remove_expired_tokens() {
-		if ($this->user && current_user_can( 'edit_user' ) && ! empty( $_GET['remove_expired_tokens'] ) ) {
+		if ($this->user && current_user_can( 'edit_users' ) && ! empty( $_GET['remove_expired_tokens'] ) ) {
 
 			$tokens = get_user_meta( $this->user->ID, 'jwt_data', true ) ?: false;
 			if ( $tokens ) {

--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -8,6 +8,7 @@
 
 // Require the JWT library.
 use \Firebase\JWT\JWT;
+use \Ramsey\Uuid\Uuid;
 
 class Simple_Jwt_Authentication_Rest {
 
@@ -79,6 +80,24 @@ class Simple_Jwt_Authentication_Rest {
 	}
 
 	/**
+	* Creates a new UUID to track the token. Attempts to generate the UUID using
+	* the WP built-in method first and falls back to ramsey/uuid
+	*
+	* @since 1.2
+	* @return String UUID
+	*/
+	private function generate_uuid() {
+	  if( function_exists( 'wp_generate_uuid4' ) ) {
+	    //Use the built in UUID generator
+	    return wp_generate_uuid4();
+	  }
+	  else {
+	    //Old version of WP, use a different UUID generator
+	    return Uuid::uuid4()->toString();
+	  }
+	}
+
+	/**
 	 * Get the user and password in the request body and generate a JWT
 	 *
 	 * @param object $request a WP REST request object
@@ -119,7 +138,7 @@ class Simple_Jwt_Authentication_Rest {
 		$issued_at = time();
 		$not_before = apply_filters( 'jwt_auth_not_before', $issued_at );
 		$expire = apply_filters( 'jwt_auth_expire', $issued_at + (DAY_IN_SECONDS * 7), $issued_at );
-		$uuid = wp_generate_uuid4();
+		$uuid = $this->generate_uuid();
 
 		$token = array(
 			'uuid' => $uuid,

--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -462,22 +462,8 @@ class Simple_Jwt_Authentication_Rest {
 			);
 		}
 
-		$key = $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM $wpdb->users WHERE user_login = %s", $user_login ) );
-		if ( empty( $key ) ) {
-			// Generate something random for a key...
-			$key = wp_generate_password( 20, false );
-			do_action( 'retrieve_password_key', $user_login, $key );
-			// Now insert the new md5 key into the db
-			$wpdb->update(
-				$wpdb->users,
-				array(
-					'user_activation_key' => $key,
-				),
-				array(
-					'user_login' => $user_login,
-				)
-			);
-		}
+		$key = get_password_reset_key( $user_data );
+		
 		$message = __( 'Someone requested that the password be reset for the following account:' ) . "\r\n\r\n";
 		$message .= network_home_url( '/' ) . "\r\n\r\n";
 		$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";

--- a/simple-jwt-authentication.php
+++ b/simple-jwt-authentication.php
@@ -3,7 +3,7 @@
  * Plugin Name: Simple JWT Authentication
  * Plugin URI:  http://github.com/jonathan-dejong/simple-jwt-authentication
  * Description: Extends the WP REST API using JSON Web Tokens Authentication as an authentication method.
- * Version:     1.1
+ * Version:     1.2
  * Author:      Jonathan de Jong
  * Author URI:  http://github.com/jonathan-dejong
  * License:     GPL-2.0+
@@ -33,7 +33,7 @@ class Simple_Jwt_Authentication {
 	public function __construct() {
 
 		$this->plugin_name = 'simple-jwt-authentication';
-		$this->plugin_version = '1.1';
+		$this->plugin_version = '1.2';
 
 		// Load all dependency files.
 		$this->load_dependencies();

--- a/simple-jwt-authentication.php
+++ b/simple-jwt-authentication.php
@@ -3,7 +3,7 @@
  * Plugin Name: Simple JWT Authentication
  * Plugin URI:  http://github.com/jonathan-dejong/simple-jwt-authentication
  * Description: Extends the WP REST API using JSON Web Tokens Authentication as an authentication method.
- * Version:     1.1
+ * Version:     1.2
  * Author:      Jonathan de Jong
  * Author URI:  http://github.com/jonathan-dejong
  * License:     GPL-2.0+


### PR DESCRIPTION
Updated the UUID generation to fallback to \Ramsey\Uuid if the wordpress version is too old to have wp_generate_uuid4.