### PR TITLE
Use WP get_password_reset_key() function instead of custom solution

### DIFF
--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -462,22 +462,8 @@ class Simple_Jwt_Authentication_Rest {
 			);
 		}
 
-		$key = $wpdb->get_var( $wpdb->prepare( "SELECT user_activation_key FROM $wpdb->users WHERE user_login = %s", $user_login ) );
-		if ( empty( $key ) ) {
-			// Generate something random for a key...
-			$key = wp_generate_password( 20, false );
-			do_action( 'retrieve_password_key', $user_login, $key );
-			// Now insert the new md5 key into the db
-			$wpdb->update(
-				$wpdb->users,
-				array(
-					'user_activation_key' => $key,
-				),
-				array(
-					'user_login' => $user_login,
-				)
-			);
-		}
+		$key = get_password_reset_key( $user_data );
+		
 		$message = __( 'Someone requested that the password be reset for the following account:' ) . "\r\n\r\n";
 		$message .= network_home_url( '/' ) . "\r\n\r\n";
 		$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";


### PR DESCRIPTION
Looks like WP already has a function to "Creates, stores, then returns a password reset key for user" in one go. Ref: https://developer.wordpress.org/reference/functions/get_password_reset_key/