### PR TITLE
several improvements

### DIFF
--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -190,7 +190,9 @@ class Simple_Jwt_Authentication_Rest {
 		// Valid credentials, the user exists create the according Token.
 		$issued_at  = time();
 		$not_before = apply_filters( 'jwt_auth_not_before', $issued_at );
-		$expire = apply_filters( 'jwt_auth_expire', $issued_at + (DAY_IN_SECONDS * 7), $issued_at );
+		$expire = apply_filters( 'jwt_auth_expire', $issued_at + (DAY_IN_SECONDS * 7), $issued_at, $user->data->ID );
+        if ( !$expire ) return false;
+        
 		$uuid = $this->generate_uuid();
 
 		$token = array(

--- a/includes/class-simple-jwt-authentication-rest.php
+++ b/includes/class-simple-jwt-authentication-rest.php
@@ -191,7 +191,7 @@ class Simple_Jwt_Authentication_Rest {
 		$issued_at  = time();
 		$not_before = apply_filters( 'jwt_auth_not_before', $issued_at );
 		$expire = apply_filters( 'jwt_auth_expire', $issued_at + (DAY_IN_SECONDS * 7), $issued_at, $user->data->ID );
-        if ( !$expire ) return false;
+		if ( !$expire ) return false;
         
 		$uuid = $this->generate_uuid();
 


### PR DESCRIPTION
* **add user_id as extra parameter of the 'jwt_auth_expire' filter** - so we can set a different expiry depending of the user.
* **fix REVOKE TOKEN buttons; was not working on the current user profile page** - now those functions are hooked on 'current_screen' instead of 'init'
* **new function generate_user_token($user_id)** - from code that was within generate_token(); which nows invokes it.  Offers a way to generate a token by user_id without the need to pass a username & password.