### PR TITLE
Prevent JWT Secret disclosure in Multisite environments with global secret

### DIFF
--- a/includes/admin/class-simple-jwt-authentication-settings.php
+++ b/includes/admin/class-simple-jwt-authentication-settings.php
@@ -83,15 +83,8 @@ class Simple_Jwt_Authentication_Settings {
 	 * @since 1.0
 	 */
 	public function settings_secret_callback() {
-        $is_global = Simple_Jwt_Authentication_Api::is_global( 'SIMPLE_JWT_AUTHENTICATION_SECRET_KEY' );
-
-        // Only display the Secret key, if it is not set in the wp-config file.
-        // In Multisite Installations it could be a security issue to display a global secret to other sites admins
-        $secret_key = __( '-- HIDDEN --', 'simple-jwt-authentication' );
-        if (!$is_global) {
-	        $secret_key = Simple_Jwt_Authentication_Api::get_key();
-        }
-
+		$secret_key = Simple_Jwt_Authentication_Api::get_key();
+		$is_global = Simple_Jwt_Authentication_Api::is_global( 'SIMPLE_JWT_AUTHENTICATION_SECRET_KEY' );
 		include plugin_dir_path( __FILE__ ) . 'views/settings/secret-key.php';
 
 	}

--- a/includes/admin/class-simple-jwt-authentication-settings.php
+++ b/includes/admin/class-simple-jwt-authentication-settings.php
@@ -83,8 +83,15 @@ class Simple_Jwt_Authentication_Settings {
 	 * @since 1.0
 	 */
 	public function settings_secret_callback() {
-		$secret_key = Simple_Jwt_Authentication_Api::get_key();
-		$is_global = Simple_Jwt_Authentication_Api::is_global( 'SIMPLE_JWT_AUTHENTICATION_SECRET_KEY' );
+        $is_global = Simple_Jwt_Authentication_Api::is_global( 'SIMPLE_JWT_AUTHENTICATION_SECRET_KEY' );
+
+        // Only display the Secret key, if it is not set in the wp-config file.
+        // In Multisite Installations it could be a security issue to display a global secret to other sites admins
+        $secret_key = __( '-- HIDDEN --', 'simple-jwt-authentication' );
+        if (!$is_global) {
+	        $secret_key = Simple_Jwt_Authentication_Api::get_key();
+        }
+
 		include plugin_dir_path( __FILE__ ) . 'views/settings/secret-key.php';
 
 	}

--- a/includes/admin/views/settings/secret-key.php
+++ b/includes/admin/views/settings/secret-key.php
@@ -1,8 +1,16 @@
-<input type="text" name='simple_jwt_authentication_settings[secret_key]' value='<?php echo $secret_key; ?>' <?php echo ( $is_global ? 'readonly' : '' ); ?> size="50" autocomplete="off" />
 <?php
+
+// Only display the Secret key, if it is not set in the wp-config file.
+// In Multisite Installations it could be a security issue to display a global secret to other sites admins
 if ( $is_global ) {
+    ?>
+    <input type="text" value="<?php _e('-- HIDDEN --', 'simple-jwt-authentication'); ?>" readonly="readonly" size="50" autocomplete="off" />
+    <?php
 	echo '<br /><small>' . __( 'Defined in wp-config.php', 'simple-jwt-authentication' ) . '</small>';
 } else {
+    ?>
+    <input type="text" name='simple_jwt_authentication_settings[secret_key]' value='<?php echo $secret_key; ?>' size="50" autocomplete="off" />
+    <?php
 	echo '<br /><small>' . __( 'Should be a long string of letters, numbers and symbols.', 'simple-jwt-authentication' ) . '</small>';
 }
 ?>


### PR DESCRIPTION
The Admin Settings UI displays the JWT Secret to everyone with "manage_options" capabilities. This is true for every single site admin in a multisite environment (see: https://wordpress.org/support/article/roles-and-capabilities/#capability-vs-role-table ).
Thus displaying the globally set JWT secret poses the thread of using the secret to forge valid JWT Tokens for other sites admin users, or even super admin users thus leading to privilege escalation.

In a single site, this cannot happen, as a user with manage_options already have the highest priviliges.

This patch removes the display of the JWT key, whenever it is set in wp-config. As there is no benefit in displaying or knowing it anyway.

Best Regards,

Jan
